### PR TITLE
Add simple portfolio website

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,17 @@
-# chatgpt
+# ChatGPT Portfolio Demo
+
+This repository contains a basic example of a portfolio website. The site files
+are located in the `portfolio` directory and include:
+
+- `index.html` – the main web page
+- `style.css` – styling for the page
+- `script.js` – simple JavaScript for form handling
+
+You can open `portfolio/index.html` directly in a browser or run a simple server
+from the repository root:
+
+```bash
+python3 -m http.server
+```
+
+Then visit `http://localhost:8000/portfolio/` in your browser.

--- a/portfolio/index.html
+++ b/portfolio/index.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>My Portfolio</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <header>
+        <h1>John Doe</h1>
+        <p>Web Developer & Designer</p>
+    </header>
+    <nav>
+        <ul>
+            <li><a href="#about">About</a></li>
+            <li><a href="#projects">Projects</a></li>
+            <li><a href="#contact">Contact</a></li>
+        </ul>
+    </nav>
+    <section id="about">
+        <h2>About Me</h2>
+        <p>Hello! I'm John, a passionate web developer. I love creating interactive and responsive websites.</p>
+    </section>
+    <section id="projects">
+        <h2>Projects</h2>
+        <div class="project-list">
+            <!-- Add your projects here -->
+        </div>
+    </section>
+    <section id="contact">
+        <h2>Contact</h2>
+        <form id="contact-form">
+            <label for="name">Name:</label>
+            <input type="text" id="name" required>
+
+            <label for="email">Email:</label>
+            <input type="email" id="email" required>
+
+            <label for="message">Message:</label>
+            <textarea id="message" rows="5" required></textarea>
+
+            <button type="submit">Send</button>
+        </form>
+    </section>
+    <footer>
+        <p>&copy; 2024 John Doe</p>
+    </footer>
+    <script src="script.js"></script>
+</body>
+</html>

--- a/portfolio/script.js
+++ b/portfolio/script.js
@@ -1,0 +1,9 @@
+// Simple form submission handler
+const form = document.getElementById('contact-form');
+if (form) {
+    form.addEventListener('submit', (e) => {
+        e.preventDefault();
+        alert('Thank you for your message!');
+        form.reset();
+    });
+}

--- a/portfolio/style.css
+++ b/portfolio/style.css
@@ -1,0 +1,64 @@
+body {
+    font-family: Arial, sans-serif;
+    line-height: 1.6;
+    margin: 0;
+    padding: 0;
+    background: #f4f4f4;
+}
+
+header {
+    background: #333;
+    color: #fff;
+    padding: 20px 0;
+    text-align: center;
+}
+
+nav ul {
+    list-style: none;
+    padding: 0;
+    text-align: center;
+    background: #444;
+    margin: 0;
+}
+
+nav ul li {
+    display: inline-block;
+}
+
+nav ul li a {
+    color: #fff;
+    padding: 15px 20px;
+    display: block;
+    text-decoration: none;
+}
+
+nav ul li a:hover {
+    background: #555;
+}
+
+section {
+    padding: 20px;
+    background: #fff;
+    margin: 20px auto;
+    max-width: 800px;
+    box-shadow: 0 0 10px rgba(0,0,0,0.1);
+}
+
+footer {
+    text-align: center;
+    padding: 20px 0;
+    background: #333;
+    color: #fff;
+}
+
+button {
+    background: #333;
+    color: #fff;
+    padding: 10px 20px;
+    border: none;
+    cursor: pointer;
+}
+
+button:hover {
+    background: #555;
+}


### PR DESCRIPTION
## Summary
- add a `portfolio` example with HTML, CSS and JS
- document how to view the site in the README

## Testing
- `python3 -m http.server --bind 127.0.0.1 8000` *(ran briefly)*

------
https://chatgpt.com/codex/tasks/task_e_6840c26572b4832c98a6ac4982e4c4dd